### PR TITLE
fixed error

### DIFF
--- a/public/libpddokdo.h
+++ b/public/libpddokdo.h
@@ -1,3 +1,4 @@
+#include <UIKit/UIKit.h>
 @class UIImage;
 
 @interface PDDokdo : NSObject


### PR DESCRIPTION
./public/libpddokdo.h:3:22: error: cannot find interface declaration for 'NSObject', superclass of 'PDDokdo'